### PR TITLE
CLOSES #7: Adds support for secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ CentOS-6 6.9 x86_64 - HAProxy 1.5 / HATop 0.7.
 
 ### 1.0.2 - Unreleased
 
-- Updates source image to [1.8.3 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.3).
+- Updates source image to [1.8.4 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.4).
+- Adds feature to set `HAPROXY_SSL_CERTIFICATE` via a file path. e.g. Docker Swarm secrets.
+- Adds feature to set `HAPROXY_CONF` via a file path. e.g. Docker Swarm secrets.
 
 ### 1.0.1 - 2018-01-22
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ There are several environmental variables defined at runtime which allows the op
 
 The HAProxy SSL/TLS certificate can be defined using `HAPROXY_SSL_CERTIFICATE`. The value may be either a file path, a base64 encoded string of the certificate file contents or a multiline string containing a PEM formatted concatenation of private key and certificate. If set to a file path the contents may also be a base64 encoded string.
 
+**Note:** If using a file path with base64 encoded content the on container path is not maintained so this feature is *not* suitable for use with orchestration secrets such as Docker Swarm secrets or config however use of unencoded file contents is.
+
 ##### HAPROXY_CONF
 
 The HAProxy configuration file path, (or base64 encoded string of the configuration file contents), is set using `HAPROXY_CONF`. The default http configuration is located at the path `/etc/haproxy/haproxy-http.example.cfg` and will be copied into the runnning configuration path `/etc/haproxy/haproxy-http.example.cfg`. There's also an example tcp configuration in the path `/etc/haproxy/haproxy-tcp.example.cfg`. 
 
-In most situations it will be necessary to define a custom configuration where the use of the base64 encoded string option is recommended.
+**Note:** In most situations it will be necessary to define a custom configuration where the use of the base64 encoded string option is recommended. However if using a file path with base64 encoded content the on container path is not maintained so this feature is *not* suitable for use with orchestration secrets such as Docker Swarm secrets or config so when using these unencoded file contents is recommended.
 
 ##### HAPROXY_HOST_NAMES
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       nproc: 65535
     volumes:
       # Emulate docker swarm secrets
-      - "${PWD}/test/fixture/secrets:/var/run/secrets"
+      - "${PWD}/test/fixture/secrets:/var/run/secrets:ro"
   httpd_1:
     environment:
       APACHE_MOD_SSL_ENABLED: "false"

--- a/src/usr/sbin/haproxy-bootstrap
+++ b/src/usr/sbin/haproxy-bootstrap
@@ -92,14 +92,11 @@ function set_haproxy_certificate ()
 		value="$(
 			base64 -d -i <<< "${value}"
 		)"
-		# Write back decoded value to source file
+		# Reset file path so unencoded value is written to container path
 		if [[ -n ${file_path} ]] \
 			&& [[ ${file_path} != ${HAPROXY_SSL_CERTIFICATE_PATH} ]]
 		then
-			printf \
-				-- '%s' \
-				"${value}" \
-			> ${file_path}
+			file_path="${HAPROXY_SSL_CERTIFICATE_PATH}"
 		fi
 	fi
 
@@ -166,14 +163,11 @@ function set_haproxy_config ()
 		value="$(
 			base64 -d -i <<< "${value}"
 		)"
-		# Write back decoded value to source file
+		# Reset file path so unencoded value is written to container path
 		if [[ -n ${file_path} ]] \
 			&& [[ ${file_path} != ${HAPROXY_CONFIG_PATH} ]]
 		then
-			printf \
-				-- '%s' \
-				"${value}" \
-			> ${file_path}
+			file_path="${HAPROXY_CONFIG_PATH}"
 		fi
 	fi
 

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -351,6 +351,11 @@ function test_custom_configuration ()
 								-i /tmp/www.app.local.pem
 						)"
 					fi
+
+					printf \
+						-- '%s' \
+						"${certificate_pem_base64}" \
+					> /tmp/www.app.local.txt
 				fi
 
 				it "Sets from base64 encoded value."
@@ -416,6 +421,60 @@ function test_custom_configuration ()
 						--detach \
 						--name haproxy.pool-1.1.1 \
 						--env HAPROXY_SSL_CERTIFICATE="/var/run/tmp/www.app.local.pem" \
+						--network ${backend_network} \
+						--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+						--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
+						--volume /tmp:/var/run/tmp:ro \
+						jdeathe/centos-ssh-haproxy:latest \
+					&> /dev/null
+
+					container_port_443="$(
+						__get_container_port \
+							haproxy.pool-1.1.1 \
+							443/tcp
+					)"
+
+					if ! __is_container_ready \
+						haproxy.pool-1.1.1 \
+						${STARTUP_TIME} \
+						"/usr/sbin/haproxy " \
+						"/usr/bin/healthcheck"
+					then
+						exit 1
+					fi
+
+					certificate_fingerprint_server="$(
+						echo -n \
+						| openssl s_client \
+							-connect 127.0.0.1:${container_port_443} \
+							-CAfile /tmp/www.app.local.pem \
+							-nbio \
+							2>&1 \
+						| sed \
+							-n \
+							-e '/^-----BEGIN CERTIFICATE-----$/,/^-----END CERTIFICATE-----$/p' \
+						| openssl \
+							x509 \
+							-fingerprint \
+							-noout \
+						| sed \
+							-e 's~SHA1 Fingerprint=~~'
+					)"
+
+					assert equal \
+						"${certificate_fingerprint_server}" \
+						"${certificate_fingerprint_file}"
+				end
+
+				it "Sets from file path with base64 encoded content."
+					__terminate_container \
+						haproxy.pool-1.1.1 \
+					&> /dev/null
+
+					docker run \
+						--detach \
+						--name haproxy.pool-1.1.1 \
+						--env HAPROXY_SSL_CERTIFICATE="/var/run/tmp/www.app.local.txt" \
 						--network ${backend_network} \
 						--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 						--publish ${DOCKER_PORT_MAP_TCP_443}:443 \


### PR DESCRIPTION
CLOSES #7

- Adds feature to set `HAPROXY_SSL_CERTIFICATE` via a file path. e.g. Docker Swarm secrets.
- Adds feature to set `HAPROXY_CONF` via a file path. e.g. Docker Swarm secrets.