### PR TITLE
CLOSES #54: Updates source image to 1.9.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 Summary of release changes for Version 1.
 
-CentOS-6 6.9 x86_64 - HAProxy 1.5 / HATop 0.7.
+CentOS-6 6.10 x86_64 - HAProxy 1.5 / HATop 0.7.
+
+### 1.1.0 - Unreleased
+
+- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).
 
 ### 1.0.3 - 2018-07-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # jdeathe/centos-ssh-haproxy
 # =============================================================================
-FROM jdeathe/centos-ssh:1.8.4
+FROM jdeathe/centos-ssh:1.9.0
 
 ARG HATOP_VERSION="0.7.7"
 
@@ -177,7 +177,7 @@ jdeathe/centos-ssh-haproxy:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-haproxy" \
-	org.deathe.description="CentOS-6 6.9 x86_64 - HAProxy 1.5 / HATop 0.7."
+	org.deathe.description="CentOS-6 6.10 x86_64 - HAProxy 1.5 / HATop 0.7."
 
 HEALTHCHECK \
 	--interval=0.5s \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.9 x86_64 - HAProxy / HATop.
+CentOS-6 6.10 x86_64 - HAProxy / HATop.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Docker Image including:
-- CentOS-6 6.9 x86_64 - HAProxy 1.5 / HATop 0.7.
-- CentOS-7 7.4.1708 x86_64 - HAProxy 1.8 / HATop 0.7.
+- CentOS-6 6.10 x86_64 - HAProxy 1.5 / HATop 0.7.
+- CentOS-7 7.5.1804 x86_64 - HAProxy 1.8 / HATop 0.7.
 
 - http://www.haproxy.org/
 - http://feurix.org/projects/hatop/

--- a/docker-compose-http-proxy.yml
+++ b/docker-compose-http-proxy.yml
@@ -30,7 +30,7 @@ services:
       VARNISH_MAX_THREADS: "4096"
       VARNISH_MIN_THREADS: "1024"
       VARNISH_VCL_CONF: "${VARNISH_VCL_CONF:-/var/run/secrets/varnish_vcl_default}"
-    image: "jdeathe/centos-ssh-varnish:2.0.0"
+    image: "jdeathe/centos-ssh-varnish:2.1.0"
     networks:
       - "tier2"
       - "tier3"
@@ -55,7 +55,7 @@ services:
       VARNISH_MAX_THREADS: "4096"
       VARNISH_MIN_THREADS: "1024"
       VARNISH_VCL_CONF: "${VARNISH_VCL_CONF:-/var/run/secrets/varnish_vcl_default}"
-    image: "jdeathe/centos-ssh-varnish:2.0.0"
+    image: "jdeathe/centos-ssh-varnish:2.1.0"
     networks:
       - "tier2"
       - "tier3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       APACHE_SERVER_NAME: "www.app.local"
       PHP_OPTIONS_SESSION_SAVE_HANDLER: "memcached"
       PHP_OPTIONS_SESSION_SAVE_PATH: "memcached:11211"
-    image: "jdeathe/centos-ssh-apache-php:2.2.6"
+    image: "jdeathe/centos-ssh-apache-php:2.3.0"
     networks:
       - "tier3"
       - "tier4"
@@ -85,7 +85,7 @@ services:
       APACHE_SERVER_NAME: "www.app.local"
       PHP_OPTIONS_SESSION_SAVE_HANDLER: "memcached"
       PHP_OPTIONS_SESSION_SAVE_PATH: "memcached:11211"
-    image: "jdeathe/centos-ssh-apache-php:2.2.6"
+    image: "jdeathe/centos-ssh-apache-php:2.3.0"
     networks:
       - "tier3"
       - "tier4"
@@ -95,7 +95,7 @@ services:
       net.ipv4.ip_local_port_range: "1024 65535"
       net.ipv4.route.flush: "1"
   memcached:
-    image: "jdeathe/centos-ssh-memcached:1.1.3"
+    image: "jdeathe/centos-ssh-memcached:1.2.0"
     environment:
       MEMCACHED_CACHESIZE: "32"
       MEMCACHED_MAXCONN: "2048"


### PR DESCRIPTION
CLOSES #54

- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).