### PR TITLE
CLOSES #53: Updates source image to 2.4.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 Summary of release changes for Version 2.
 
-CentOS-7 7.4.1708 x86_64 - HAProxy 1.8 / HATop 0.7.
+CentOS-7 7.5.1804 x86_64 - HAProxy 1.8 / HATop 0.7.
 
 ### 2.1.0 - Unreleased
 
 - Updates `haproxy18u` packages to 1.8.12-1.
 - Updates `rsyslog` packages to 8.24.0-16.el7_5.4.
+- Updates source image to [2.4.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.0).
 
 ### 2.0.0 - 2018-07-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # jdeathe/centos-ssh-haproxy
 # =============================================================================
-FROM jdeathe/centos-ssh:2.3.2
+FROM jdeathe/centos-ssh:2.4.0
 
 ARG HATOP_VERSION="0.7.7"
 
@@ -183,7 +183,7 @@ jdeathe/centos-ssh-haproxy:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-haproxy" \
-	org.deathe.description="CentOS-7 7.4.1708 x86_64 - HAProxy 1.8 / HATop 0.7."
+	org.deathe.description="CentOS-7 7.5.1804 x86_64 - HAProxy 1.8 / HATop 0.7."
 
 HEALTHCHECK \
 	--interval=0.5s \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-7 7.4.1708 x86_64 - HAProxy / HATop.
+CentOS-7 7.5.1804 x86_64 - HAProxy / HATop.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ centos-ssh-haproxy
 ==================
 
 Docker Image including:
-- CentOS-6 6.9 x86_64 - HAProxy 1.5 / HATop 0.7.
-- CentOS-7 7.4.1708 x86_64 - HAProxy 1.8 / HATop 0.7.
+- CentOS-6 6.10 x86_64 - HAProxy 1.5 / HATop 0.7.
+- CentOS-7 7.5.1804 x86_64 - HAProxy 1.8 / HATop 0.7.
 
 - http://www.haproxy.org/
 - http://feurix.org/projects/hatop/

--- a/docker-compose-h2-proxy.yml
+++ b/docker-compose-h2-proxy.yml
@@ -30,7 +30,7 @@ services:
       VARNISH_MAX_THREADS: "4096"
       VARNISH_MIN_THREADS: "1024"
       VARNISH_VCL_CONF: "${VARNISH_VCL_CONF:-/run/secrets/varnish_vcl_terminated_https}"
-    image: "jdeathe/centos-ssh-varnish:2.0.0"
+    image: "jdeathe/centos-ssh-varnish:2.1.0"
     networks:
       - "tier2"
       - "tier3"
@@ -55,7 +55,7 @@ services:
       VARNISH_MAX_THREADS: "4096"
       VARNISH_MIN_THREADS: "1024"
       VARNISH_VCL_CONF: "${VARNISH_VCL_CONF:-/run/secrets/varnish_vcl_terminated_https}"
-    image: "jdeathe/centos-ssh-varnish:2.0.0"
+    image: "jdeathe/centos-ssh-varnish:2.1.0"
     networks:
       - "tier2"
       - "tier3"

--- a/docker-compose-http-proxy.yml
+++ b/docker-compose-http-proxy.yml
@@ -30,7 +30,7 @@ services:
       VARNISH_MAX_THREADS: "4096"
       VARNISH_MIN_THREADS: "1024"
       VARNISH_VCL_CONF: "${VARNISH_VCL_CONF:-/run/secrets/varnish_vcl_default}"
-    image: "jdeathe/centos-ssh-varnish:2.0.0"
+    image: "jdeathe/centos-ssh-varnish:2.1.0"
     networks:
       - "tier2"
       - "tier3"
@@ -55,7 +55,7 @@ services:
       VARNISH_MAX_THREADS: "4096"
       VARNISH_MIN_THREADS: "1024"
       VARNISH_VCL_CONF: "${VARNISH_VCL_CONF:-/run/secrets/varnish_vcl_default}"
-    image: "jdeathe/centos-ssh-varnish:2.0.0"
+    image: "jdeathe/centos-ssh-varnish:2.1.0"
     networks:
       - "tier2"
       - "tier3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       APACHE_SERVER_NAME: "www.app.local"
       PHP_OPTIONS_SESSION_SAVE_HANDLER: "memcached"
       PHP_OPTIONS_SESSION_SAVE_PATH: "memcached:11211"
-    image: "jdeathe/centos-ssh-apache-php:3.0.1"
+    image: "jdeathe/centos-ssh-apache-php:3.1.0"
     networks:
       - "tier3"
       - "tier4"
@@ -85,7 +85,7 @@ services:
       APACHE_SERVER_NAME: "www.app.local"
       PHP_OPTIONS_SESSION_SAVE_HANDLER: "memcached"
       PHP_OPTIONS_SESSION_SAVE_PATH: "memcached:11211"
-    image: "jdeathe/centos-ssh-apache-php:3.0.1"
+    image: "jdeathe/centos-ssh-apache-php:3.1.0"
     networks:
       - "tier3"
       - "tier4"
@@ -95,7 +95,7 @@ services:
       net.ipv4.ip_local_port_range: "1024 65535"
       net.ipv4.route.flush: "1"
   memcached:
-    image: "jdeathe/centos-ssh-memcached:2.0.0"
+    image: "jdeathe/centos-ssh-memcached:2.1.0"
     environment:
       MEMCACHED_CACHESIZE: "32"
       MEMCACHED_MAXCONN: "2048"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -94,7 +94,7 @@ function __setup ()
 	local -r backend_name_1="apache-php.pool-1.1.1"
 	local -r backend_name_2="apache-php.pool-1.1.2"
 	local -r backend_network="bridge_t1"
-	local -r backend_release="2.2.5"
+	local -r backend_release="3.1.0"
 
 	# Create the bridge network
 	if [[ -z $(docker network ls -q -f name="${backend_network}") ]]; then


### PR DESCRIPTION
CLOSES #53

- Updates source image to [2.4.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.0).