### PR TITLE
CLOSES #88: Adds Haproxy /status monitor-ui feature to http examples.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ CentOS-7 7.5.1804 x86_64 - HAProxy 1.8 / HATop 0.7.
 - Adds support for hitless reload via `haproxy-wrapper`.
 - Adds configuration of Apache certificate via `APACHE_SSL_CERTIFICATE` in `.env` for the tcp example.
 - Adds SNI forwarding in the TLS/SSL tcp example configuration.
+- Adds `/status` (`monitor-uri`) endpoints and custom error responses to http example configuration.
 - Removes use of `/etc/services-config` paths.
 - Removes the unused group element from the default container name.
 - Removes the node element from the default container name.

--- a/docker-compose-h2-proxy.yml
+++ b/docker-compose-h2-proxy.yml
@@ -15,6 +15,10 @@
 # docker-compose exec haproxy hatop -s /var/lib/haproxy/stats-2 -i 1
 # docker-compose exec haproxy hatop -s /var/lib/haproxy/stats-3 -i 1
 # docker-compose exec haproxy hatop -s /var/lib/haproxy/stats-4 -i 1
+#
+# Varnish usage:
+# docker-compose -f docker-compose.yml -f docker-compose-h2-proxy.yml \
+#   exec varnish1 varnishadm help
 # ------------------------------------------------------------------------------
 version: "3.0"
 networks:

--- a/docker-compose-http-proxy.yml
+++ b/docker-compose-http-proxy.yml
@@ -15,6 +15,10 @@
 # docker-compose exec haproxy hatop -s /var/lib/haproxy/stats-2 -i 1
 # docker-compose exec haproxy hatop -s /var/lib/haproxy/stats-3 -i 1
 # docker-compose exec haproxy hatop -s /var/lib/haproxy/stats-4 -i 1
+#
+# Varnish usage:
+# docker-compose -f docker-compose.yml -f docker-compose-http-proxy.yml \
+#   exec varnish1 varnishadm help
 # ------------------------------------------------------------------------------
 version: "3.0"
 networks:

--- a/src/etc/haproxy/200.html.http
+++ b/src/etc/haproxy/200.html.http
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/plain; charset=UTF-8
+Retry-After: 5
+X-Frame-Options: DENY
+X-XSS-Protection: 1; mode=block
+
+OK

--- a/src/etc/haproxy/503-monitor.html.http
+++ b/src/etc/haproxy/503-monitor.html.http
@@ -1,0 +1,9 @@
+HTTP/1.1 503 Service Unavailable
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/plain; charset=UTF-8
+Retry-After: 5
+X-Frame-Options: DENY
+X-XSS-Protection: 1; mode=block
+
+Service Unavailable

--- a/src/etc/haproxy/haproxy-h2-proxy.cfg
+++ b/src/etc/haproxy/haproxy-h2-proxy.cfg
@@ -28,6 +28,7 @@ global
 defaults
 	bind-process 1
 	default-server maxconn 2048 rise 3 fall 3 inter 5s downinter 2s fastinter 2s
+	errorfile 200 /etc/haproxy/200.html.http
 	errorfile 400 /etc/haproxy/400.html.http
 	errorfile 403 /etc/haproxy/403.html.http
 	errorfile 408 /etc/haproxy/408.html.http
@@ -80,7 +81,10 @@ listen tls-termination
 frontend http
 	backlog 10240
 	bind 0.0.0.0:80 nice 10
+	errorfile 503 /etc/haproxy/503-monitor.html.http if { path -m str /status }
 	maxconn 10240
+	monitor fail if { nbsrv(https) lt 1 }
+	monitor-uri /status
 	rate-limit sessions 2048
 	redirect scheme https code 301 if !{ ssl_fc }
 
@@ -90,7 +94,10 @@ frontend https
 	bind /tls-termination-3.sock accept-proxy maxconn 10240
 	bind /tls-termination-4.sock accept-proxy maxconn 10240
 	default_backend https
+	errorfile 503 /etc/haproxy/503-monitor.html.http if { path -m str /status }
 	maxconn 10240
+	monitor fail if { nbsrv(https) lt 1 }
+	monitor-uri /status
 	rate-limit sessions 2048
 
 # ------------------------------------------------------------------------------

--- a/src/etc/haproxy/haproxy-h2.cfg
+++ b/src/etc/haproxy/haproxy-h2.cfg
@@ -28,6 +28,7 @@ global
 defaults
 	bind-process 1
 	default-server maxconn 1028 rise 3 fall 3 inter 5s downinter 2s fastinter 2s
+	errorfile 200 /etc/haproxy/200.html.http
 	errorfile 400 /etc/haproxy/400.html.http
 	errorfile 403 /etc/haproxy/403.html.http
 	errorfile 408 /etc/haproxy/408.html.http
@@ -80,7 +81,10 @@ listen tls-termination
 frontend http
 	backlog 10240
 	bind 0.0.0.0:80 nice 10
+	errorfile 503 /etc/haproxy/503-monitor.html.http if { path -m str /status }
 	maxconn 10240
+	monitor fail if { nbsrv(https) lt 1 }
+	monitor-uri /status
 	rate-limit sessions 2048
 	redirect scheme https code 301 if !{ ssl_fc }
 
@@ -90,7 +94,10 @@ frontend https
 	bind /tls-termination-3.sock accept-proxy maxconn 10240
 	bind /tls-termination-4.sock accept-proxy maxconn 10240
 	default_backend https
+	errorfile 503 /etc/haproxy/503-monitor.html.http if { path -m str /status }
 	maxconn 10240
+	monitor fail if { nbsrv(https) lt 1 }
+	monitor-uri /status
 	rate-limit sessions 2048
 
 # ------------------------------------------------------------------------------

--- a/src/etc/haproxy/haproxy-http-proxy.cfg
+++ b/src/etc/haproxy/haproxy-http-proxy.cfg
@@ -28,6 +28,7 @@ global
 defaults
 	bind-process 1
 	default-server maxconn 2048 rise 3 fall 3 inter 5s downinter 2s fastinter 2s
+	errorfile 200 /etc/haproxy/200.html.http
 	errorfile 400 /etc/haproxy/400.html.http
 	errorfile 403 /etc/haproxy/403.html.http
 	errorfile 408 /etc/haproxy/408.html.http
@@ -81,7 +82,10 @@ frontend http
 	backlog 10240
 	bind 0.0.0.0:80 nice 10
 	default_backend http
+	errorfile 503 /etc/haproxy/503-monitor.html.http if { path -m str /status }
 	maxconn 10240
+	monitor fail if { nbsrv(http) lt 1 }
+	monitor-uri /status
 	rate-limit sessions 2048
 
 frontend https
@@ -90,7 +94,10 @@ frontend https
 	bind /tls-termination-3.sock accept-proxy maxconn 10240
 	bind /tls-termination-4.sock accept-proxy maxconn 10240
 	default_backend https
+	errorfile 503 /etc/haproxy/503-monitor.html.http if { path -m str /status }
 	maxconn 10240
+	monitor fail if { nbsrv(https) lt 1 }
+	monitor-uri /status
 	rate-limit sessions 2048
 
 # ------------------------------------------------------------------------------

--- a/src/etc/haproxy/haproxy-http.cfg
+++ b/src/etc/haproxy/haproxy-http.cfg
@@ -28,6 +28,7 @@ global
 defaults
 	bind-process 1
 	default-server maxconn 1028 rise 3 fall 3 inter 5s downinter 2s fastinter 2s
+	errorfile 200 /etc/haproxy/200.html.http
 	errorfile 400 /etc/haproxy/400.html.http
 	errorfile 403 /etc/haproxy/403.html.http
 	errorfile 408 /etc/haproxy/408.html.http
@@ -81,7 +82,10 @@ frontend http
 	backlog 10240
 	bind 0.0.0.0:80 nice 10
 	default_backend http
+	errorfile 503 /etc/haproxy/503-monitor.html.http if { path -m str /status }
 	maxconn 10240
+	monitor fail if { nbsrv(http) lt 1 }
+	monitor-uri /status
 	rate-limit sessions 2048
 
 frontend https
@@ -90,7 +94,10 @@ frontend https
 	bind /tls-termination-3.sock accept-proxy maxconn 10240
 	bind /tls-termination-4.sock accept-proxy maxconn 10240
 	default_backend https
+	errorfile 503 /etc/haproxy/503-monitor.html.http if { path -m str /status }
 	maxconn 10240
+	monitor fail if { nbsrv(https) lt 1 }
+	monitor-uri /status
 	rate-limit sessions 2048
 
 # ------------------------------------------------------------------------------

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -319,7 +319,7 @@ function test_basic_operations ()
 		end
 
 		describe "Monitor URI"
-			describe "Backend healthy"
+			describe "Backend up"
 				describe "Unencrypted response"
 					it "Is 200 OK."
 						backend_response_code="$(

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -366,10 +366,6 @@ function test_basic_operations ()
 			end
 
 			describe "Backend down"
-
-				# set server https/web_1 drain
-				# set server http/web_1 drain
-
 				# Take backends down
 				docker pause \
 					${backend_name_1} \


### PR DESCRIPTION
CLOSES #88

- Adds `/status` (`monitor-uri`) endpoints and custom error responses to http example configuration.